### PR TITLE
[FIRE-80] Slower fire spread

### DIFF
--- a/src/main/java/pl/edu/agh/firecell/core/diagnostics/DiagnosticsManager.java
+++ b/src/main/java/pl/edu/agh/firecell/core/diagnostics/DiagnosticsManager.java
@@ -1,8 +1,8 @@
 package pl.edu.agh.firecell.core.diagnostics;
 
-import pl.edu.agh.firecell.engine.algorithm.BasicAlgorithm;
-import pl.edu.agh.firecell.model.material.Material;
+import pl.edu.agh.firecell.engine.algorithm.AlgorithmUtils;
 import pl.edu.agh.firecell.model.State;
+import pl.edu.agh.firecell.model.material.Material;
 
 public class DiagnosticsManager {
 
@@ -52,24 +52,36 @@ public class DiagnosticsManager {
     }
 
     public double averageSolidsTemperature() {
-        return solidsTemperature / (double)solidsCellsCount;
+        return solidsTemperature / (double) solidsCellsCount;
     }
 
     public double averageAirTemperature() {
-        return airTemperature / (double)airCellsCount;
+        return airTemperature / (double) airCellsCount;
     }
 
-    public double totalSmokeValue(){ return totalSmokeValue; }
+    public double totalSmokeValue() {
+        return totalSmokeValue;
+    }
 
-    public double minSmokeValue(){ return minSmokeValue; }
+    public double minSmokeValue() {
+        return minSmokeValue;
+    }
 
-    public double maxSmokeValue(){ return maxSmokeValue; }
+    public double maxSmokeValue() {
+        return maxSmokeValue;
+    }
 
-    public double totalOxygenValue(){ return totalOxygenValue; }
+    public double totalOxygenValue() {
+        return totalOxygenValue;
+    }
 
-    public double minOxygenValue(){ return minOxygenValue; }
+    public double minOxygenValue() {
+        return minOxygenValue;
+    }
 
-    public double maxOxygenValue(){ return maxOxygenValue; }
+    public double maxOxygenValue() {
+        return maxOxygenValue;
+    }
 
     private void processState() {
         totalTemperature = 0.0;
@@ -105,7 +117,7 @@ public class DiagnosticsManager {
                 solidsCellsCount += 1;
             }
 
-            if (BasicAlgorithm.isCellBurning(cell)) {
+            if (AlgorithmUtils.isCellBurning(cell)) {
                 burningCellsCount += 1;
             }
         });

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/AlgorithmUtils.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/AlgorithmUtils.java
@@ -1,13 +1,14 @@
-package pl.edu.agh.firecell.model.util;
+package pl.edu.agh.firecell.engine.algorithm;
 
 import org.joml.Vector3i;
 import pl.edu.agh.firecell.model.Cell;
 import pl.edu.agh.firecell.model.State;
 import pl.edu.agh.firecell.model.material.Material;
+import pl.edu.agh.firecell.model.util.NeighbourUtils;
 
 import java.util.stream.Stream;
 
-public class HelpfulFunctions {
+public class AlgorithmUtils {
 
     public static boolean isUpNeighbourAir(State state, Vector3i cellIndex) {
         Vector3i upIndex = NeighbourUtils.up(cellIndex);

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/BasicAlgorithm.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/BasicAlgorithm.java
@@ -31,21 +31,25 @@ public class BasicAlgorithm implements Algorithm {
 
         Cell oldCell = oldState.getCell(cellIndex);
 
+        // Temperature propagation
         double newTemperature = temperaturePropagator.computeConduction(oldState, cellIndex, oldCell.temperature());
         if (oldCell.material().getMatterState().equals(MatterState.FLUID))
             newTemperature = temperaturePropagator.computeConvection(oldState, cellIndex, newTemperature);
 
-        double newSmokeIndicator = smokePropagator.computeNewSmokeIndicator(oldState, cellIndex, oldCell);
-
+        // Fire propagation
         int newRemainingFirePillar = firePropagator.computeFirePillar(oldState, oldCell, cellIndex, oldCell.remainingFirePillar());
         int newBurningTime = firePropagator.computeBurningTime(oldState, oldCell, cellIndex, newTemperature);
-        boolean newFlammable = firePropagator.computeNewFlammable(oldCell, newBurningTime);
+        boolean newFlammable = firePropagator.computeNewFlammable(oldState, cellIndex, newBurningTime);
         newTemperature = temperaturePropagator.updateTemperatureBasedOnFire(oldCell, newTemperature);
 
+        // Smoke propagation
+        double newSmokeIndicator = smokePropagator.computeNewSmokeIndicator(oldState, cellIndex, oldCell);
+
+        // Diffusion
         if (oldCell.isFluid())
             newSmokeIndicator = diffusionGenerator.smokeUpdate(oldState, cellIndex, newSmokeIndicator);
         newTemperature = diffusionGenerator.temperatureUpdate(oldState, cellIndex, newTemperature);
-        newOxygenLevel = oxygenPropagator.makeUseOfOxygen(oldState, cellIndex, oldCell.oxygenLevel());
+        double newOxygenLevel = oxygenPropagator.makeUseOfOxygen(oldState, cellIndex, oldCell.oxygenLevel());
         newOxygenLevel = diffusionGenerator.oxygenUpdate(oldState, cellIndex, newOxygenLevel);
 
         return new Cell(

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/BasicAlgorithm.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/BasicAlgorithm.java
@@ -16,11 +16,6 @@ public class BasicAlgorithm implements Algorithm {
     private final FirePropagator firePropagator;
     private final SmokePropagator smokePropagator;
     private final DiffusionGenerator diffusionGenerator;
-    public static final double CONVECTION_COEFFICIENT = 1;
-    // should be dependent on the material in the future
-    public static final double CONDUCTIVITY_COEFFICIENT = 0.2;
-    public static final int MAX_BURNING_TIME = 50;
-
 
     public BasicAlgorithm(double deltaTime) throws ConductionCoefficientException {
         this.temperaturePropagator = new TemperaturePropagator(deltaTime);
@@ -33,26 +28,18 @@ public class BasicAlgorithm implements Algorithm {
     public Cell compute(State oldState, Vector3i cellIndex) {
 
         Cell oldCell = oldState.getCell(cellIndex);
-        double newTemperature = oldCell.temperature();
-        int newBurningTime;
-        int newRemainingFirePillar;
-        boolean newFlammable;
-        // NOTE: Following method calls are dependent on each other, the order matters.
-        // Conduction
-        newTemperature = temperaturePropagator.computeConduction(oldState, cellIndex, newTemperature);
-        // Convection
-        if(oldCell.material().getMatterState().equals(MatterState.FLUID))
-            newTemperature = temperaturePropagator.computeConvection(oldState, cellIndex, newTemperature);
-        // Smoke update
-        double newSmokeIndicator = smokePropagator.computeNewSmokeIndicator(oldState, cellIndex, oldCell);
-        // Fire status update
-        newRemainingFirePillar = firePropagator.computeFirePillar(oldState, oldCell, cellIndex, oldCell.remainingFirePillar());
-        newBurningTime = firePropagator.computeBurningTime(oldState, oldCell, cellIndex, newTemperature);
-        newFlammable = firePropagator.computeNewFlammable(oldCell, newBurningTime);
-        newTemperature = temperaturePropagator.updateTemperatureBasedOnFire(oldCell, newTemperature);
 
-        // Diffusion update
+        double newTemperature = temperaturePropagator.computeConduction(oldState, cellIndex, oldCell.temperature());
+        if (oldCell.material().getMatterState().equals(MatterState.FLUID))
+            newTemperature = temperaturePropagator.computeConvection(oldState, cellIndex, newTemperature);
+
+        double newSmokeIndicator = smokePropagator.computeNewSmokeIndicator(oldState, cellIndex, oldCell);
         diffusionGenerator.smokeUpdate(oldState, cellIndex);
+
+        int newRemainingFirePillar = firePropagator.computeFirePillar(oldState, oldCell, cellIndex, oldCell.remainingFirePillar());
+        int newBurningTime = firePropagator.computeBurningTime(oldState, oldCell, cellIndex, newTemperature);
+        boolean newFlammable = firePropagator.computeNewFlammable(oldCell, newBurningTime);
+        newTemperature = temperaturePropagator.updateTemperatureBasedOnFire(oldCell, newTemperature);
 
         return new Cell(
                 newTemperature,

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/BasicAlgorithm.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/BasicAlgorithm.java
@@ -5,10 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.edu.agh.firecell.model.Cell;
 import pl.edu.agh.firecell.model.exception.ConductionCoefficientException;
-import pl.edu.agh.firecell.model.material.Material;
 import pl.edu.agh.firecell.model.material.MatterState;
 import pl.edu.agh.firecell.model.State;
-import pl.edu.agh.firecell.model.util.NeighbourUtils;
 
 
 public class BasicAlgorithm implements Algorithm {
@@ -66,12 +64,4 @@ public class BasicAlgorithm implements Algorithm {
         );
     }
 
-    public static boolean isUpNeighbourAir(State state, Vector3i cellIndex) {
-        Vector3i upIndex = NeighbourUtils.up(cellIndex);
-        return state.hasCell(upIndex) && state.getCell(upIndex).material().equals(Material.AIR);
-    }
-
-    public static boolean isCellBurning(Cell cell) {
-        return cell.flammable() && cell.burningTime() > 0;
-    }
 }

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/FirePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/FirePropagator.java
@@ -9,6 +9,7 @@ import pl.edu.agh.firecell.model.util.NeighbourUtils;
 import java.util.stream.Stream;
 
 import static pl.edu.agh.firecell.engine.algorithm.BasicAlgorithm.*;
+import static pl.edu.agh.firecell.model.util.HelpfulFunctions.*;
 
 public class FirePropagator {
 
@@ -59,14 +60,7 @@ public class FirePropagator {
         return Math.max(downFirePillar, neighbourFirePillar);
     }
 
-    public static Stream<Vector3i> getBurningHorizontalNeighbours(State oldState, Vector3i cellIndex) {
-        return Stream
-                .concat(NeighbourUtils.neighboursStream(cellIndex, NeighbourUtils.Axis.X), NeighbourUtils.neighboursStream(cellIndex, NeighbourUtils.Axis.Z))
-                .filter(neighbourIndex -> oldState.hasCell(neighbourIndex) &&
-                        isCellBurning(oldState.getCell(neighbourIndex)) &&
-                        oldState.getCell(neighbourIndex).remainingFirePillar() > 0 &&
-                        !isUpNeighbourAir(oldState, neighbourIndex));
-    }
+
 
     private int computeBurningTimeWood(State oldState, Vector3i cellIndex, double newTemperature, int currenBurningTime) {
         Cell oldCell = oldState.getCell(cellIndex);
@@ -94,9 +88,5 @@ public class FirePropagator {
                 .filter(oldState::hasCell)
                 .map(oldState::getCell)
                 .anyMatch(cell -> cell.burningTime() > REQUIRED_TIME);
-    }
-
-    private static boolean isCellBurning(Cell cell) {
-        return cell.flammable() && cell.burningTime() > 0;
     }
 }

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/FirePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/FirePropagator.java
@@ -14,7 +14,7 @@ public class FirePropagator {
 
     // Required time period to set on fire neighbour cell with temperature
     // higher than ignition temperature
-    private static final int REQUIRED_TIME = 10;
+    private static final int REQUIRED_TIME = 25;
 
     public boolean computeNewFlammable(Cell oldCell, int newBurningTime) {
         return switch (oldCell.material()) {
@@ -70,21 +70,22 @@ public class FirePropagator {
 
     private int computeBurningTimeWood(State oldState, Vector3i cellIndex, double newTemperature, int currenBurningTime) {
         Cell oldCell = oldState.getCell(cellIndex);
-        int newBurningTime = currenBurningTime;
-        if (oldCell.burningTime() == 0 &&
-                MAX_BURNING_TIME != 0 &&
-                oldCell.flammable()) {
+
+        if (oldCell.burningTime() == 0 && MAX_BURNING_TIME != 0 && oldCell.flammable()) {
+
             if (newTemperature > Material.WOOD.autoIgnitionTemperature()) {
-                newBurningTime++;
-            } else if (shouldIgniteFromNeighbour(oldState, cellIndex) &&
-                    newTemperature > Material.WOOD.ignitionTemperature()) {
-                newBurningTime++;
+                return 1;
+
+            } else if (shouldIgniteFromNeighbour(oldState, cellIndex)
+                    && newTemperature > Material.WOOD.ignitionTemperature()) {
+                return 1;
             }
         }
+
         if (oldCell.burningTime() > 0 && oldCell.burningTime() <= MAX_BURNING_TIME) {
-            newBurningTime++;
+            return currenBurningTime + 1;
         }
-        return newBurningTime;
+        return currenBurningTime;
     }
 
     private boolean shouldIgniteFromNeighbour(State oldState, Vector3i cellIndex) {

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/FirePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/FirePropagator.java
@@ -8,11 +8,10 @@ import pl.edu.agh.firecell.model.util.NeighbourUtils;
 
 import java.util.stream.Stream;
 
-import static pl.edu.agh.firecell.engine.algorithm.BasicAlgorithm.*;
-import static pl.edu.agh.firecell.model.util.HelpfulFunctions.*;
 
 public class FirePropagator {
 
+    private static final int MAX_BURNING_TIME = 50;
     // Required time period to set on fire neighbour cell with temperature
     // higher than ignition temperature
     private static final int REQUIRED_TIME = 25;
@@ -40,15 +39,15 @@ public class FirePropagator {
         // from under
         int downFirePillar = 0;
         if (oldState.hasCell(NeighbourUtils.down(cellIndex)) &&
-                isCellBurning(oldState.getCell(NeighbourUtils.down(cellIndex))) &&
+                AlgorithmUtils.isCellBurning(oldState.getCell(NeighbourUtils.down(cellIndex))) &&
                 oldState.getCell(NeighbourUtils.down(cellIndex)).remainingFirePillar() > 1) {
             downFirePillar = oldState.getCell(NeighbourUtils.down(cellIndex)).remainingFirePillar() - 1;
         }
 
         // from neighbour
         int neighbourFirePillar = 0;
-        int horizontalNeighbourFirePillar = getBurningHorizontalNeighbours(oldState, cellIndex)
-                .filter(neighbourIndex -> !isUpNeighbourAir(oldState, neighbourIndex) &&
+        int horizontalNeighbourFirePillar = AlgorithmUtils.getBurningHorizontalNeighbours(oldState, cellIndex)
+                .filter(neighbourIndex -> !AlgorithmUtils.isUpNeighbourAir(oldState, neighbourIndex) &&
                         oldState.getCell(neighbourIndex).remainingFirePillar() - 1 > 0)
                 .map(neighbourIndex -> oldState.getCell(neighbourIndex).remainingFirePillar())
                 .max(Integer::compareTo)

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/OxygenPropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/OxygenPropagator.java
@@ -2,8 +2,8 @@ package pl.edu.agh.firecell.engine.algorithm;
 
 import org.joml.Vector3i;
 import pl.edu.agh.firecell.model.Cell;
-import pl.edu.agh.firecell.model.material.Material;
 import pl.edu.agh.firecell.model.State;
+import pl.edu.agh.firecell.model.material.Material;
 
 public class OxygenPropagator {
 
@@ -15,7 +15,7 @@ public class OxygenPropagator {
 
     public double makeUseOfOxygen(State oldState, Vector3i cellIndex, double currentOxygenLevel) {
         Cell oldCell = oldState.getCell(cellIndex);
-        if (BasicAlgorithm.isCellBurning(oldCell) &&
+        if (AlgorithmUtils.isCellBurning(oldCell) &&
                 oldCell.material().equals(Material.AIR) &&
                 currentOxygenLevel > 0) {
             return Math.max(0, currentOxygenLevel - (deltaTime * FirePropagator.OXYGEN_USAGE_IN_FIRE));

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/SmokePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/SmokePropagator.java
@@ -9,7 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static pl.edu.agh.firecell.engine.algorithm.BasicAlgorithm.isCellBurning;
+import static pl.edu.agh.firecell.model.util.HelpfulFunctions.isCellBurning;
+
 
 public class SmokePropagator {
 

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/SmokePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/SmokePropagator.java
@@ -9,9 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static pl.edu.agh.firecell.model.util.HelpfulFunctions.isCellBurning;
-
-
 public class SmokePropagator {
 
     private final double deltaTime;
@@ -39,7 +36,7 @@ public class SmokePropagator {
     private double generateSmoke(State oldState, Vector3i cellIndex) {
         double smokeFromFire = 0;
         if (oldState.hasCell(NeighbourUtils.down(cellIndex)) &&
-                isCellBurning(oldState.getCell(NeighbourUtils.down(cellIndex))) &&
+                AlgorithmUtils.isCellBurning(oldState.getCell(NeighbourUtils.down(cellIndex))) &&
                 oldState.getCell(NeighbourUtils.down(cellIndex)).isSolid()) {
             smokeFromFire = oldState.getCell(NeighbourUtils.down(cellIndex)).material().smokeCoe();
         }
@@ -52,7 +49,7 @@ public class SmokePropagator {
                             )
                         )
                         .map(oldState::getCell)
-                        .filter(cell -> isCellBurning(cell)&&cell.isSolid())
+                        .filter(cell -> AlgorithmUtils.isCellBurning(cell)&&cell.isSolid())
                         .mapToDouble(cell -> cell.material().smokeCoe() / 4.0).sum();
         return smokeFromFire;
     }

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
@@ -8,12 +8,10 @@ import pl.edu.agh.firecell.model.State;
 import pl.edu.agh.firecell.model.util.NeighbourUtils;
 
 
-import static pl.edu.agh.firecell.engine.algorithm.BasicAlgorithm.*;
-import static pl.edu.agh.firecell.model.util.HelpfulFunctions.*;
-
 public class TemperaturePropagator {
 
     private static final double BURNING_TEMPERATURE_COEFFICIENT = 0.3;
+    private static final double CONVECTION_COEFFICIENT = 1;
 
     private final double deltaTime;
     private final MaterialConductionMap materialConductionMap;
@@ -57,7 +55,8 @@ public class TemperaturePropagator {
     }
 
     private double computeConductivity(Cell former, Cell middle, Cell latter, double conductivityCoeFormer, double conductivityCoeFurther) {
-        return -(conductivityCoeFormer * tempDiff(middle, former) + conductivityCoeFurther * tempDiff(middle, latter));
+        return -(conductivityCoeFormer * AlgorithmUtils.tempDiff(middle, former)
+                        + conductivityCoeFurther * AlgorithmUtils.tempDiff(middle, latter));
     }
 
     public double computeConvection(State oldState, Vector3i cellIndex, double currentTemperature) {
@@ -67,21 +66,21 @@ public class TemperaturePropagator {
         try {
             Cell cellUnder = oldState.getCell(NeighbourUtils.down(cellIndex));
             if (cellUnder.isFluid() && cellUnder.temperature() > oldCell.temperature())
-                temperatureDifference += CONVECTION_COEFFICIENT * tempDiffAbs(oldCell, cellUnder);
+                temperatureDifference += CONVECTION_COEFFICIENT * AlgorithmUtils.tempDiffAbs(oldCell, cellUnder);
         } catch (IndexOutOfBoundsException ignored) {
         }
 
         try {
             Cell cellAbove = oldState.getCell(NeighbourUtils.up(cellIndex));
             if (cellAbove.isFluid() && cellAbove.temperature() < oldCell.temperature())
-                temperatureDifference -= CONVECTION_COEFFICIENT * tempDiffAbs(oldCell, cellAbove);
+                temperatureDifference -= CONVECTION_COEFFICIENT * AlgorithmUtils.tempDiffAbs(oldCell, cellAbove);
         } catch (IndexOutOfBoundsException ignored) {
         }
         return currentTemperature + deltaTime * temperatureDifference;
     }
 
     public double updateTemperatureBasedOnFire(Cell oldCell, double currentTemperature) {
-        if (!isCellBurning(oldCell))
+        if (!AlgorithmUtils.isCellBurning(oldCell))
             return currentTemperature;
 
         double diffToMaterialBurningTemperature = oldCell.material().getBurningTemperature() - currentTemperature;

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
@@ -12,6 +12,8 @@ import static pl.edu.agh.firecell.engine.algorithm.BasicAlgorithm.*;
 
 public class TemperaturePropagator {
 
+    private static final double BURNING_TEMPERATURE_COEFFICIENT = 0.3;
+
     private final double deltaTime;
     private final MaterialConductionMap materialConductionMap;
 
@@ -83,7 +85,7 @@ public class TemperaturePropagator {
 
         double diffToMaterialBurningTemperature = oldCell.material().getBurningTemperature() - currentTemperature;
         if (diffToMaterialBurningTemperature > 0)
-            return currentTemperature + deltaTime * diffToMaterialBurningTemperature;
+            return currentTemperature + diffToMaterialBurningTemperature * deltaTime * BURNING_TEMPERATURE_COEFFICIENT;
 
         return currentTemperature;
     }

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
@@ -9,6 +9,7 @@ import pl.edu.agh.firecell.model.util.NeighbourUtils;
 
 
 import static pl.edu.agh.firecell.engine.algorithm.BasicAlgorithm.*;
+import static pl.edu.agh.firecell.model.util.HelpfulFunctions.*;
 
 public class TemperaturePropagator {
 
@@ -90,15 +91,4 @@ public class TemperaturePropagator {
         return currentTemperature;
     }
 
-    private static double tempDiffAbs(Cell cellOne, Cell cellTwo) {
-        return Math.abs(tempDiff(cellOne, cellTwo));
-    }
-
-    private static double tempDiff(Cell cellOne, Cell cellTwo) {
-        return cellOne.temperature() - cellTwo.temperature();
-    }
-
-    private static boolean isCellBurning(Cell cell) {
-        return cell.flammable() && cell.burningTime() > 0;
-    }
 }

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
@@ -78,7 +78,14 @@ public class TemperaturePropagator {
     }
 
     public double updateTemperatureBasedOnFire(Cell oldCell, double currentTemperature) {
-        return oldCell.burningTime() > 0 && oldCell.flammable() ? oldCell.material().getBurningTemperature() : currentTemperature;
+        if (!isCellBurning(oldCell))
+            return currentTemperature;
+
+        double diffToMaterialBurningTemperature = oldCell.material().getBurningTemperature() - currentTemperature;
+        if (diffToMaterialBurningTemperature > 0)
+            return deltaTime * diffToMaterialBurningTemperature;
+
+        return currentTemperature;
     }
 
     private static double tempDiffAbs(Cell cellOne, Cell cellTwo) {
@@ -89,4 +96,7 @@ public class TemperaturePropagator {
         return cellOne.temperature() - cellTwo.temperature();
     }
 
+    private static boolean isCellBurning(Cell cell) {
+        return cell.flammable() && cell.burningTime() > 0;
+    }
 }

--- a/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
+++ b/src/main/java/pl/edu/agh/firecell/engine/algorithm/TemperaturePropagator.java
@@ -83,7 +83,7 @@ public class TemperaturePropagator {
 
         double diffToMaterialBurningTemperature = oldCell.material().getBurningTemperature() - currentTemperature;
         if (diffToMaterialBurningTemperature > 0)
-            return deltaTime * diffToMaterialBurningTemperature;
+            return currentTemperature + deltaTime * diffToMaterialBurningTemperature;
 
         return currentTemperature;
     }

--- a/src/main/java/pl/edu/agh/firecell/model/util/HelpfulFunctions.java
+++ b/src/main/java/pl/edu/agh/firecell/model/util/HelpfulFunctions.java
@@ -1,0 +1,38 @@
+package pl.edu.agh.firecell.model.util;
+
+import org.joml.Vector3i;
+import pl.edu.agh.firecell.model.Cell;
+import pl.edu.agh.firecell.model.State;
+import pl.edu.agh.firecell.model.material.Material;
+
+import java.util.stream.Stream;
+
+public class HelpfulFunctions {
+
+    public static boolean isUpNeighbourAir(State state, Vector3i cellIndex) {
+        Vector3i upIndex = NeighbourUtils.up(cellIndex);
+        return state.hasCell(upIndex) && state.getCell(upIndex).material().equals(Material.AIR);
+    }
+
+    public static boolean isCellBurning(Cell cell) {
+        return cell.flammable() && cell.burningTime() > 0;
+    }
+
+    public static Stream<Vector3i> getBurningHorizontalNeighbours(State oldState, Vector3i cellIndex) {
+        return Stream
+                .concat(NeighbourUtils.neighboursStream(cellIndex, NeighbourUtils.Axis.X), NeighbourUtils.neighboursStream(cellIndex, NeighbourUtils.Axis.Z))
+                .filter(neighbourIndex -> oldState.hasCell(neighbourIndex) &&
+                        isCellBurning(oldState.getCell(neighbourIndex)) &&
+                        oldState.getCell(neighbourIndex).remainingFirePillar() > 0 &&
+                        !isUpNeighbourAir(oldState, neighbourIndex));
+    }
+
+    public static double tempDiffAbs(Cell cellOne, Cell cellTwo) {
+        return Math.abs(tempDiff(cellOne, cellTwo));
+    }
+
+    public static double tempDiff(Cell cellOne, Cell cellTwo) {
+        return cellOne.temperature() - cellTwo.temperature();
+    }
+
+}


### PR DESCRIPTION
Made fire spread slower by:
1. Increasing time needed for ignition from neighbor
2. Made burning cells not receive immediately full material burning temp, instead temperature is rising asymptotically to the limit.